### PR TITLE
Fix custom-logo favicon: update every icon link, not just the first

### DIFF
--- a/web/src/hooks/use-site-config.tsx
+++ b/web/src/hooks/use-site-config.tsx
@@ -42,10 +42,15 @@ export function SiteConfigProvider({ children }: { children: ReactNode }) {
           attribution_url: data.attribution_url || "https://keygate.app",
           loading: false,
         })
-        // Dynamic favicon from custom logo
+        // Dynamic favicon from custom logo. index.html declares
+        // multiple <link rel="icon"> variants and browsers pick their
+        // favorite (often the sizes="32x32" one), so rewriting only
+        // the first link never visibly changed the tab icon — update
+        // them all.
         if (data.logo_url) {
-          const link = document.querySelector("link[rel='icon']") as HTMLLinkElement
-          if (link) link.href = data.logo_url
+          document.querySelectorAll<HTMLLinkElement>("link[rel~='icon']").forEach((link) => {
+            link.href = data.logo_url
+          })
         }
         if (data.brand_color) {
           document.documentElement.style.setProperty("--color-primary", data.brand_color)


### PR DESCRIPTION
## What does this PR do?
Makes the existing "use the custom logo as the favicon" behavior actually take effect. index.html declares two <link rel="icon"> tags (an SVG one and a sizes="32x32" one), but use-site-config.tsx rewrote only the first match via querySelector. Browsers pick their preferred icon declaration — Chrome tends to prefer the one with explicit sizes — so the stock Keygate favicon kept winning and the tab icon never visibly changed.

The fix rewrites every matching link (querySelectorAll("link[rel~='icon']")) and leaves a comment explaining why, so it doesn't regress to the single-link form later.

## Why?
Setting a custom logo_url in Settings → Branding is documented to also brand the browser tab, but in practice the favicon never changed — the update silently hit only the icon declaration the browser ignores. Discovered while self-hosting; confirmed by inspecting the live DOM (first link had the custom URL, second still pointed at /favicon.svg).

## How to test
* Admin >Settings > Branding: set a custom Logo URL (any reachable PNG/SVG) and save.
* Reload the dashboard and inspect document.querySelectorAll("link[rel~='icon']") — both links should now point at the custom URL (before this fix, only the first did).
* The browser tab shows the custom icon.

With no custom logo set, the stock favicon is untouched.

## Checklist

- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] Frontend builds (`cd web && bun run build`)
- [x] Tested manually in browser running in production