### PR TITLE
Fix docker-compose postgres volume mount for postgres 18 images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,10 @@ services:
       POSTGRES_PASSWORD: keygate
       POSTGRES_DB: keygate
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      # postgres:18+ images expect the volume mounted at /var/lib/postgresql
+      # (data lives in a versioned subdirectory); mounting .../data makes
+      # initdb fail on a fresh volume. https://github.com/docker-library/postgres/issues/37
+      - pgdata:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U keygate"]
       interval: 10s


### PR DESCRIPTION
## Problem

A fresh `docker compose up -d` from the quick-start instructions never becomes healthy. The postgres container restarts in a loop with:

```
There appears to be PostgreSQL data in:
  /var/lib/postgresql/data (unused mount/volume)
```

and since the keygate service waits on `condition: service_healthy`, keygate never starts either.

## Cause

The compose file pins `postgres:18-alpine`. Starting with the postgres 18 official images, the data directory moved into a versioned subdirectory and the suggested mount point changed from `/var/lib/postgresql/data` to `/var/lib/postgresql` — mounting the old path breaks `initdb` on a fresh volume. See https://github.com/docker-library/postgres/issues/37

## Fix

Mount the `pgdata` volume at `/var/lib/postgresql` (with a short comment explaining why, so it doesn't get "simplified" back).

## Verification

- Before: fresh clone + `.env` + `docker compose up -d` → postgres unhealthy, keygate never starts (macOS, Docker 28/29).
- After: same steps on a brand-new volume → both containers healthy, `/health` returns `{"status":"ok"}`.

Note: existing deployments that already have data under the old layout will need the usual `pg_upgrade` path when moving postgres majors — this change only affects where the volume is mounted, not the data itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)