### PR TITLE
Fix setup wizard 500: include checkout_id in default plan insert

### DIFF
--- a/internal/handler/setup.go
+++ b/internal/handler/setup.go
@@ -173,8 +173,8 @@ func (h *SetupHandler) Initialize(c *gin.Context) {
 		maxActivations, maxSeats = 3, 10
 	}
 	if _, err := tx.NewRaw(
-		"INSERT INTO plans (id, product_id, name, slug, license_type, max_activations, max_seats, grace_days, active, created_at) VALUES (?, ?, 'Pro', 'pro', 'subscription', ?, ?, 7, true, now())",
-		planID, productID, maxActivations, maxSeats,
+		"INSERT INTO plans (id, product_id, name, slug, license_type, max_activations, max_seats, grace_days, active, checkout_id, created_at) VALUES (?, ?, 'Pro', 'pro', 'subscription', ?, ?, 7, true, ?, now())",
+		planID, productID, maxActivations, maxSeats, store.ShortID(),
 	).Exec(ctx); err != nil {
 		response.Internal(c)
 		return

--- a/internal/store/admin.go
+++ b/internal/store/admin.go
@@ -78,6 +78,10 @@ func shortID() string {
 	return hex.EncodeToString(b)[:8]
 }
 
+// ShortID generates a URL-safe 8-character unique ID for checkout links.
+// Exported for use by the setup handler.
+func ShortID() string { return shortID() }
+
 func (s *Store) UpdatePlan(ctx context.Context, p *model.Plan) error {
 	_, err := s.DB.NewUpdate().Model(p).WherePK().Exec(ctx)
 	return err


### PR DESCRIPTION
## Problem

On every fresh install, the setup wizard fails: `POST /api/v1/setup/initialize` returns `500 {"code":"INTERNAL_ERROR"}` (both through the UI and via curl), so a new deployment can never get past initial setup.

The server log only shows the 500 (the wizard's error paths call `response.Internal` without logging the underlying error), but replaying the wizard's INSERTs against the database surfaces the actual failure:

```
ERROR:  null value in column "checkout_id" of relation "plans" violates not-null constraint
```

## Cause

Migration `20260401_plan_checkout_id` added `plans.checkout_id TEXT NOT NULL UNIQUE`. The admin path fills it (`store.CreatePlan` → `shortID()`), but the setup wizard's raw plan INSERT in `internal/handler/setup.go` was never updated to include the column.

## Fix

- Export the existing helper as `store.ShortID()` — following the exact precedent of `store.NewID()`, which carries the comment "Exported for use by setup handler".
- Include `checkout_id` in the wizard's plan INSERT.

## Verification

Built the image from this branch and ran a fresh install (new postgres volume):

- Before: `POST /api/v1/setup/initialize` → 500 on every attempt.
- After: → `{"success":true,...}`; `SELECT slug, checkout_id FROM plans` shows the default plan with a populated 8-char checkout_id, and the rest of the bootstrap flow (login, license mint, SDK activate/verify) works end to end.

Possible follow-up (out of scope here): logging the underlying error in the wizard's `response.Internal` paths would have made this 500 self-diagnosing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)